### PR TITLE
Close figure after being saved in display mode

### DIFF
--- a/umt/umt_utils.py
+++ b/umt/umt_utils.py
@@ -84,7 +84,8 @@ def persist_image_output(pil_img, trackers, tracker_labels, tracker_scores, COLO
         ax.add_patch(rect)
         
     plt.savefig(f'output/frame_{frame}.jpg', bbox_inches='tight', pad_inches=0)
-
+    plt.close()
+    
     pass
 
 


### PR DESCRIPTION
Keeps memory from expanding continually, noticeable when using -display mode for more than ~20 frames on a RPI 3B