### PR TITLE
Feature request - expose prometheus metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
 		'filterpy',
 		'imutils',
 		'numpy',
-		'Pillow',
+		'pillow',
 	    	'opencv-python',
                 'prometheus_client',
 		'scipy',

--- a/umt/deep_sort/generate_detections.py
+++ b/umt/deep_sort/generate_detections.py
@@ -78,9 +78,9 @@ class ImageEncoder(object):
             graph_def.ParseFromString(file_handle.read())
         tf.import_graph_def(graph_def, name="net")
         self.input_var = tf.get_default_graph().get_tensor_by_name(
-            "%s:0" % input_name)
+            "net/%s:0" % input_name)
         self.output_var = tf.get_default_graph().get_tensor_by_name(
-            "%s:0" % output_name)
+            "net/%s:0" % output_name)
 
         assert len(self.output_var.get_shape()) == 2
         assert len(self.input_var.get_shape()) == 4

--- a/umt/umt_main.py
+++ b/umt/umt_main.py
@@ -46,7 +46,8 @@ def main():
     parser.add_argument('-nframes', dest='nframes', type=int, required=False, default=10, help='specify nunber of frames to process')
     parser.add_argument('-display', dest='live_view', required=False, default=False, action='store_true', help='add this flag to view a live display. note, that this will greatly slow down the fps rate.')
     parser.add_argument('-save', dest='save_frames', required=False, default=False, action='store_true', help='add this flag if you want to persist the image output. note, that this will greatly slow down the fps rate.')
-    parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='enable prometheus metrics on port 8000')
+    parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='enable prometheus metrics')
+    parser.add_argument('-metricport', dest='metric_port', type=int, required=False, default=8000, help='prometheus metrics port (default 8000)')
     parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.txt. note, file is still created, just not written to.')
     args = parser.parse_args()
     
@@ -78,6 +79,10 @@ def main():
 
         track_count_hwm = 0 # Track id high water mark
         track_count = Gauge('umt_tracked_objects', 'Number of objects that have been tracked')
+
+        print('   > METRIC PORT',args.metric_port)
+        print('   > STARTING METRIC SERVER')
+        start_http_server(args.metric_port)
 
     # create output directory
     if not os.path.exists('output') and args.save_frames: os.makedirs('output')
@@ -173,7 +178,6 @@ def main():
 #--- MAIN ---------------------------------------------------------------------+
 
 if __name__ == '__main__':
-    start_http_server(8000)
     main()
 
 #--- END ----------------------------------------------------------------------+

--- a/umt/umt_main.py
+++ b/umt/umt_main.py
@@ -49,7 +49,7 @@ def main():
     parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='enable prometheus metrics')
     parser.add_argument('-metricport', dest='metric_port', type=int, required=False, default=8000, help='prometheus metrics port (default 8000)')
     parser.add_argument('-initlabelcounters', dest='init_label_counters', required=False, default=False, action='store_true', help='metrics return 0 for all possible label counters available in the model')
-    parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.txt. note, file is still created, just not written to.')
+    parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.csv. note, file is still created, just not written to.')
     args = parser.parse_args()
     
     # basic checks

--- a/umt/umt_main.py
+++ b/umt/umt_main.py
@@ -48,6 +48,7 @@ def main():
     parser.add_argument('-save', dest='save_frames', required=False, default=False, action='store_true', help='add this flag if you want to persist the image output. note, that this will greatly slow down the fps rate.')
     parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='enable prometheus metrics')
     parser.add_argument('-metricport', dest='metric_port', type=int, required=False, default=8000, help='prometheus metrics port (default 8000)')
+    parser.add_argument('-initlabelcounters', dest='init_label_counters', required=False, default=False, action='store_true', help='metrics return 0 for all possible label counters available in the model')
     parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.txt. note, file is still created, just not written to.')
     args = parser.parse_args()
     
@@ -74,8 +75,9 @@ def main():
         frames.labels(result='error')
 
         label_counter = Counter ('umt_label_counter', 'Number of each label counted', ['type'])
-        for label in labels.values():
-            label_counter.labels(type=label)
+        if args.init_label_counters:
+            for label in labels.values():
+                label_counter.labels(type=label)
 
         track_count_hwm = 0 # Track id high water mark
         track_count = Gauge('umt_tracked_objects', 'Number of objects that have been tracked')

--- a/umt/umt_main.py
+++ b/umt/umt_main.py
@@ -48,7 +48,7 @@ def main():
     parser.add_argument('-save', dest='save_frames', required=False, default=False, action='store_true', help='add this flag if you want to persist the image output. note, that this will greatly slow down the fps rate.')
     parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='add this flag to enable prometheus metrics')
     parser.add_argument('-metricport', dest='metric_port', type=int, required=False, default=8000, help='specify the prometheus metrics port (default 8000)')
-    parser.add_argument('-initlabelcounters', dest='init_label_counters', required=False, default=False, action='store_true', help='add this flag to return 0 for all possible label counter metrics available in the model')
+    parser.add_argument('-initlabelcounters', dest='init_object_counters', required=False, default=False, action='store_true', help='add this flag to return 0 for all possible object counter metrics available in the model')
     parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.csv. note, file is still created, just not written to.')
     args = parser.parse_args()
     
@@ -74,10 +74,10 @@ def main():
         frames.labels(result='detection')
         frames.labels(result='error')
 
-        label_counter = Counter ('umt_label_counter', 'Number of each label counted', ['type'])
-        if args.init_label_counters:
+        object_counter = Counter ('umt_object_counter', 'Number of each object counted', ['type'])
+        if args.init_object_counters:
             for label in labels.values():
-                label_counter.labels(type=label)
+                object_counter.labels(type=label)
 
         track_count_hwm = 0 # Track id high water mark
         track_count = Gauge('umt_tracked_objects', 'Number of objects that have been tracked')
@@ -144,7 +144,7 @@ def main():
                             if track.track_id > track_count_hwm: # new thing being tracked
                                 track_count_hwm = track.track_id
                                 track_count.set(track.track_id)
-                                label_counter.labels(type=class_name).inc()
+                                object_counter.labels(type=class_name).inc()
                 
             # only for live display
             if args.live_view or args.save_frames:

--- a/umt/umt_main.py
+++ b/umt/umt_main.py
@@ -46,6 +46,7 @@ def main():
     parser.add_argument('-nframes', dest='nframes', type=int, required=False, default=10, help='specify nunber of frames to process')
     parser.add_argument('-display', dest='live_view', required=False, default=False, action='store_true', help='add this flag to view a live display. note, that this will greatly slow down the fps rate.')
     parser.add_argument('-save', dest='save_frames', required=False, default=False, action='store_true', help='add this flag if you want to persist the image output. note, that this will greatly slow down the fps rate.')
+    parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='enable prometheus metrics on port 8000')
     parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.txt. note, file is still created, just not written to.')
     args = parser.parse_args()
     
@@ -64,12 +65,16 @@ def main():
     # initialize detector
     interpreter = initialize_detector(args)
 
-    # initialize counters for metrics
-    frames = Counter('umt_frame_counter', 'Number of frames processed')
+    if args.metrics:
+        # initialize counters for metrics
+        frames = Counter('umt_frame_counter', 'Number of frames processed', ['result'])
+        frames.labels(result='no_detection')
+        frames.labels(result='detection')
+        frames.labels(result='error')
 
-    label_counter = Counter ('umt_label_counter', 'Number of each label counted', ['type'])
-    for label in labels.values():
-        label_counter.labels(type=label)
+        label_counter = Counter ('umt_label_counter', 'Number of each label counted', ['type'])
+        for label in labels.values():
+            label_counter.labels(type=label)
 
     # create output directory
     if not os.path.exists('output') and args.save_frames: os.makedirs('output')
@@ -103,15 +108,19 @@ def main():
             detections = generate_detections(pil_img, interpreter, args.threshold)
 			
             # proceed to updating state
-            if len(detections) == 0: print('   > no detections...')
+            if len(detections) == 0:
+                print('   > no detections...')
+                if args.metrics: frames.labels(result='no_detection').inc()
             else:
-            
+                # update metric
+                if args.metrics: frames.labels(result='detection').inc()
+
                 # update tracker
                 tracker.predict()
                 tracker.update(detections)
                 
                 # save object locations
-                if len(tracker.tracks) > 0:
+                if len(tracker.tracks) > 0 and not args.nolog:
                     for track in tracker.tracks:
                         bbox = track.to_tlbr()
                         class_name = labels[track.get_class()]

--- a/umt/umt_main.py
+++ b/umt/umt_main.py
@@ -46,9 +46,9 @@ def main():
     parser.add_argument('-nframes', dest='nframes', type=int, required=False, default=10, help='specify nunber of frames to process')
     parser.add_argument('-display', dest='live_view', required=False, default=False, action='store_true', help='add this flag to view a live display. note, that this will greatly slow down the fps rate.')
     parser.add_argument('-save', dest='save_frames', required=False, default=False, action='store_true', help='add this flag if you want to persist the image output. note, that this will greatly slow down the fps rate.')
-    parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='enable prometheus metrics')
-    parser.add_argument('-metricport', dest='metric_port', type=int, required=False, default=8000, help='prometheus metrics port (default 8000)')
-    parser.add_argument('-initlabelcounters', dest='init_label_counters', required=False, default=False, action='store_true', help='metrics return 0 for all possible label counters available in the model')
+    parser.add_argument('-metrics', dest='metrics', required=False, default=False, action='store_true', help='add this flag to enable prometheus metrics')
+    parser.add_argument('-metricport', dest='metric_port', type=int, required=False, default=8000, help='specify the prometheus metrics port (default 8000)')
+    parser.add_argument('-initlabelcounters', dest='init_label_counters', required=False, default=False, action='store_true', help='add this flag to return 0 for all possible label counter metrics available in the model')
     parser.add_argument('-nolog', dest='nolog', required=False, default=False, action='store_true', help='add this flag to disable logging to object_paths.csv. note, file is still created, just not written to.')
     args = parser.parse_args()
     


### PR DESCRIPTION
I thought it would be nice to make the counters for how many objects have been counted available to prometheus/grafana. It defaults to making these available on port 8000 as metrics like:

umt_object_counter_total{type="vehicle"} 14.0

along with frame counters such as:

umt_frame_counter_total{result="no_detection"} 1361.0
umt_frame_counter_total{result="detection"} 304.0
umt_frame_counter_total{result="error"} 0.0

As part of this I've also added a command line option to disable logging to object_paths.csv (in my case, so I didn't run out of disk space).

<img width="2027" alt="Grafana screenshot - RPI metrics" src="https://user-images.githubusercontent.com/60860638/104137919-45599300-5405-11eb-837c-479856f18169.png">


FYI, this fork also includes the patch to fix the deepsort camera bug mentioned in https://github.com/nathanrooy/rpi-urban-mobility-tracker/issues/9