### PR TITLE
adding version number to deep-sort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get install -y vim
 RUN apt-get install -y git
 
 # install deep sort
-RUN pip3 install git+https://github.com/mk-michal/deep_sort
+RUN pip3 install git+https://github.com/mk-michal/deep_sort.git@v1.2.0
 
 # install umt
 RUN pip3 install git+https://github.com/nathanrooy/rpi-urban-mobility-tracker --no-deps


### PR DESCRIPTION
This solves the crux of issue #26 

The deep-sort repo updated some code that is not immediately compatible with the current version of umt, so adding the version number on in the pip install line for the dockerfile solves this issue.